### PR TITLE
Release event not triggered when github token is used

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,8 +1,9 @@
 name: Publish package
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Create release"]
+    types: [completed]
 
 jobs:
   create-release:


### PR DESCRIPTION
Apparently Release event is not triggered when release is created by Action using Github token. Work around could be to use PAT instead but for now we will keep it as trigger by completion of release workflow